### PR TITLE
Remove non used code

### DIFF
--- a/fednode.py
+++ b/fednode.py
@@ -59,12 +59,12 @@ CONFIGCHECK_FILES_BASE = [
     ['counterparty', 'client.testnet.conf.default', 'client.testnet.conf'],
     ['counterparty', 'server.conf.default', 'server.conf'],
     ['counterparty', 'server.testnet.conf.default', 'server.testnet.conf'],
-];
+]
 CONFIGCHECK_FILES_COUNTERBLOCK = CONFIGCHECK_FILES_BASE + [
     ['counterblock', 'server.conf.default', 'server.conf'],
     ['counterblock', 'server.testnet.conf.default', 'server.testnet.conf'],
 ]
-CONFIGCHECK_FILES_FULL = CONFIGCHECK_FILES_COUNTERBLOCK;
+CONFIGCHECK_FILES_FULL = CONFIGCHECK_FILES_COUNTERBLOCK
 CONFIGCHECK_FILES = {
     'base': CONFIGCHECK_FILES_BASE,
     'counterblock': CONFIGCHECK_FILES_COUNTERBLOCK,
@@ -220,14 +220,14 @@ def config_check(build_config):
         try:
             fromfilepath = os.path.join(SCRIPTDIR, 'config', dirname, fromfile)
             fromdate = file_mtime(fromfilepath)
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             print("Config file not found at {}".format(fromfilepath))
             continue
 
         try:
             tofilepath = os.path.join(SCRIPTDIR, 'config', dirname, tofile)
             todate = file_mtime(tofilepath)
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             print("Config file not found at {}".format(tofilepath))
             continue
     


### PR DESCRIPTION
日本語
1. pythonにおいて``;``は非推奨です(何もしません)
2. ``as e`` の後に``e``を使用していない為、削除しました

追記 ``;``は改行の意味は持つようです
例
```
num1 = 10;num2 = 8;num3 = 12
print (num1 + num2 + num3)
```

English
1. In python``;`` is deprecated (doesn't do anything)
2. Removed as I didn't use an ``e`` after the ``as e``

PS ; seems to have a line break meaning
Example.
```
num1 = 10;num2 = 8;num3 = 12
print (num1 + num2 + num3)
```
